### PR TITLE
Add a joke to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,13 @@
 The Anysphere whitepaper describes our exact threat model and how we achieve security against threats in the model.
 
 In short, Anysphere protects all information about a conversation between A and B, against any attacker, as long as the attacker does not have access to A's or B's computers.
+
+---
+
+## A Cryptography Joke
+
+Why did the cryptographer break up with their significant other?
+
+Because they couldn't find the right key to their heart!
+
+*This joke is cryptographically signed with my digital signature, so you know it's authentic.*


### PR DESCRIPTION
Add a new cryptography joke to the README.

The previous joke section was found to be missing from the README, so a new section with a cryptography joke was added as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-1233e92d-e73d-44aa-875a-dbfc48501068"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1233e92d-e73d-44aa-875a-dbfc48501068"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

