### PR TITLE
Placeholder task for future development

### DIFF
--- a/introduction.tex
+++ b/introduction.tex
@@ -6,7 +6,7 @@
 
 % From the start, Anysphere has assumed a single important security principle: \textit{no needless trust}. This simple principle guide Anysphere's development and is the key motivator behind our architecture, our threat model, and our choice of private information retrieval as our core protocol. 
 
-% Quite simply, we believe that communication must place no needless trust in systems across the internet since many conversations are so meaningful\todo{impactful?} that unwarranted trust can lead to harm. In particular, we currently only trust the local device and your friends. That is it.
+% Quite simply, we believe that communication must place no needless trust in systems across the internet since many conversations are so meaningful and impactful that unwarranted trust can lead to harm. In particular, we currently only trust the local device and your friends. That is it.
 
 % Our principles are fundamentally different from Signal, Email, and other platforms and protocols that assume trust in the servers, in the plumbing of the internet, and in networks being so large that no entity can monitor them. We also solve many of the practical problems that plague research prototypes. We are working hard to make Anysphere more secure, and we are working hard to make it extremely security realistic for everyone.
 

--- a/trustestablishment.tex
+++ b/trustestablishment.tex
@@ -108,7 +108,7 @@ This trust establishment protocol needs no third party, which means that it comp
           If Bob accepts, he responds to Alice.
           \begin{enumerate}
               \item \textbf{Decode.} Bob decodes $\id_A = (\ki_A^P, \kx_A^P, i_A)$. He computes the shared secret $k =  \DH(\kx_B^P, \kx^S_A)$ with Alice. He adds $i_A$ to the list of indices he listens to.
-              \item \textbf{ACK.} Bob recieves the invitation message from Alice, $\inv_{AB}$. Bob ACKs the message.
+              \item \textbf{ACK.} Bob receives the invitation message from Alice, $\inv_{AB}$. Bob ACKs the message.
               \item \textbf{ACK received.} Alice sees the ACK, finalizing the trust establishment.
           \end{enumerate}
     \medskip


### PR DESCRIPTION
Remove `\todo` comment and integrate suggested word into sentence, and fix a typo in `trustestablishment.tex`.

These changes address minor issues identified during the content review of the whitepaper, improving clarity and correctness.

---
<a href="http://localhost:4000/background-agent?bcId=bc-7afafdf5-20b6-432a-a517-94f58a71e4b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="http://localhost:4000/agents?id=bc-7afafdf5-20b6-432a-a517-94f58a71e4b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

